### PR TITLE
Install nginx reverse proxy with the native package manager

### DIFF
--- a/tasks/app/configs.yml
+++ b/tasks/app/configs.yml
@@ -39,19 +39,27 @@
     - src: nginx.conf.j2
       dest: nginx.conf
 
+- name: Create nginx config directory
+  become: true
+  file:
+    path: /etc/nginx/conf.d
+    state: directory
+
 - name: Generate nginx proxy config
+  become: true
   template:
     src: 'templates/app/config/nginx/{{ item.src }}'
-    dest: '{{ app_root }}/config/nginx/{{ item.dest }}'
+    dest: '/etc/nginx/{{ item.dest }}'
     mode: 0644
   with_items:
     - src: nginx.conf.j2
       dest: nginx.conf
 
 - name: Generate nginx proxy conf.d files
+  become: true
   template:
     src: 'templates/app/config/nginx/conf.d/{{ item.src }}'
-    dest: '{{ app_root }}/config/nginx/conf.d/{{ item.dest }}'
+    dest: '/etc/nginx/conf.d/{{ item.dest }}'
     mode: 0644
   with_items:
     - src: ssl.conf.j2
@@ -69,15 +77,17 @@
     update_cache: yes
 
 - name: Generate nginx htpasswd-dywa file
+  become: true
   htpasswd:
-    dest: '{{ app_root }}/config/nginx/htpasswd-dywa'
+    dest: '/etc/nginx/htpasswd-dywa'
     name: '{{ dywa_http_auth_username }}'
     password: '{{ dywa_http_auth_password }}'
     mode: 0644
 
 - name: Generate nginx htpasswd-mailcatcher file
+  become: true
   htpasswd:
-    dest: '{{ app_root }}/config/nginx/htpasswd-mailcatcher'
+    dest: '/etc/nginx/htpasswd-mailcatcher'
     name: '{{ mailcatcher_http_auth_username }}'
     password: '{{ mailcatcher_http_auth_password }}'
     mode: 0644

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,7 @@
 - import_tasks: user.yml
 - import_tasks: docker_swarm.yml
 - import_tasks: certbot.yml
+- import_tasks: reverse_proxy.yml
 - import_tasks: app/directories.yml
 - import_tasks: app/configs.yml
 - import_tasks: app/docker.yml

--- a/tasks/reverse_proxy.yml
+++ b/tasks/reverse_proxy.yml
@@ -1,0 +1,5 @@
+- name: Install nginx
+  become: true
+  apt:
+    name: ['nginx']
+    state: present

--- a/templates/app/docker-compose.yml.j2
+++ b/templates/app/docker-compose.yml.j2
@@ -14,37 +14,6 @@ volumes:
   postgres:
 
 services:
-  nginx:
-    image: nginx:{{ nginx_version }}
-    deploy:
-      replicas: 0
-    networks:
-      - dywa-app
-{% if deployment_tier != 'production' %}
-      - mailcatcher
-{% endif %}
-      - webapp
-    depends_on:
-      - dywa-app
-{% if deployment_tier != 'production' %}
-      - mailcatcher
-{% endif %}
-      - webapp
-    ports:
-      - "80:80"
-      - "443:443"
-      - "8080:8080"
-    volumes:
-      - "./config/nginx/conf.d/dywa-app.conf:/etc/nginx/conf.d/dywa-app.conf:ro"
-      - "./config/nginx/conf.d/ssl.conf:/etc/nginx/conf.d/ssl.conf:ro"
-      - "./config/nginx/conf.d/webapp.conf:/etc/nginx/conf.d/webapp.conf:ro"
-      - "./config/nginx/htpasswd-dywa:/etc/nginx/htpasswd-dywa:ro"
-{% if deployment_tier != 'production' %}
-      - "./config/nginx/htpasswd-mailcatcher:/etc/nginx/htpasswd-mailcatcher:ro"
-{% endif %}
-      - "./config/nginx/nginx.conf:/etc/nginx/nginx.conf:ro"
-      - "/etc/letsencrypt:/etc/letsencrypt:ro"
-      - "/var/www/certbot:/var/www/certbot:ro"
   webapp:
     image: scce/webapp:latest
     deploy:


### PR DESCRIPTION
Closes #70

One thing that is still missing here is a handler to restart nginx after the config files are copied over. The config files cannot be copied over before nginx is installed because then apt-get chokes. https://docs.ansible.com/ansible/latest/user_guide/playbooks_intro.html#handlers-running-operations-on-change